### PR TITLE
Use esphome.h include so ESP_LOGx logs to HA, MQTT

### DIFF
--- a/src/FujiHeatPump.cpp
+++ b/src/FujiHeatPump.cpp
@@ -3,6 +3,11 @@
 // #define DEBUG_FUJI
 #include "FujiHeatPump.h"
 
+// The esphome ESP_LOGx macros expand to reference esp_log_printf_, but do so
+// without using its namespace. https://github.com/esphome/issues/issues/3196
+// The workaround is to pull that particular function into this namespace.
+using esphome::esp_log_printf_;
+
 FujiFrame FujiHeatPump::decodeFrame() {
     FujiFrame ff;
 

--- a/src/FujiHeatPump.h
+++ b/src/FujiHeatPump.h
@@ -1,7 +1,8 @@
 /* This file is based on unreality's FujiHeatPump project */
 #pragma once
-#include <Arduino.h>
-#include <HardwareSerial.h>
+
+#include "esphome.h"
+#include "HardwareSerial.h"
 
 const byte kModeIndex = 3;
 const byte kModeMask = 0b00001110;


### PR DESCRIPTION
FujiHeatPump.cpp used ESP_LOGx from Arduino.h, which doesn't log to the
other places the esphome logger will (i.e. via HA and MQTT). This
complicates debugging of the protocol decode, making it impossible to do
so via the network.